### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/325/03/85632503.geojson
+++ b/data/856/325/03/85632503.geojson
@@ -919,6 +919,10 @@
     },
     "wof:country":"DM",
     "wof:country_alpha3":"DMA",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"5b01c6806d3a27d5e90911c13d81a2d2",
     "wof:hierarchy":[
         {
@@ -933,7 +937,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566581566,
+    "wof:lastmodified":1582331739,
     "wof:name":"Dominica",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/890/442/101/890442101.geojson
+++ b/data/890/442/101/890442101.geojson
@@ -434,6 +434,10 @@
     },
     "wof:country":"DM",
     "wof:created":1469052350,
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "unknown"
+    ],
     "wof:geomhash":"2dd795e7e86b99fa8f3b30b9f23d6d73",
     "wof:hierarchy":[
         {
@@ -444,7 +448,7 @@
         }
     ],
     "wof:id":890442101,
-    "wof:lastmodified":1566581576,
+    "wof:lastmodified":1582331739,
     "wof:name":"Roseau",
     "wof:parent_id":85670503,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.