### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/102/553/891/102553891.geojson
+++ b/data/102/553/891/102553891.geojson
@@ -13,6 +13,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":13.0,
+    "name:arz_x_preferred":[
+        "\u0645\u0637\u0627\u0631 \u062f\u0648\u062c\u0644\u0627\u0633 \u062a\u0634\u0627\u0631\u0644\u0632"
+    ],
     "name:ast_x_preferred":[
         "Aeropuertu Douglas\u2013Charles"
     ],
@@ -65,6 +68,9 @@
     "name:ron_x_preferred":[
         "Aeroportul Douglas\u2013Charles"
     ],
+    "name:rus_x_preferred":[
+        "\u0414\u0443\u0433\u043b\u0430\u0441\u2013\u0427\u0430\u0440\u043b\u044c\u0437"
+    ],
     "name:spa_x_preferred":[
         "Aeropuerto Douglas\u2013Charles"
     ],
@@ -108,7 +114,7 @@
         }
     ],
     "wof:id":102553891,
-    "wof:lastmodified":1631747382,
+    "wof:lastmodified":1690874873,
     "wof:name":"Melville Hall Airport",
     "wof:parent_id":85670495,
     "wof:placetype":"campus",

--- a/data/112/587/372/3/1125873723.geojson
+++ b/data/112/587/372/3/1125873723.geojson
@@ -37,6 +37,9 @@
     "name:eng_x_preferred":[
         "Grand Bay"
     ],
+    "name:eng_x_variant":[
+        "Berekua"
+    ],
     "name:fas_x_preferred":[
         "\u06af\u0631\u0627\u0646\u062f \u0628\u06cc"
     ],
@@ -45,6 +48,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05d2\u05e8\u05d0\u05e0\u05d3 \u05d1\u05d9\u05d9"
+    ],
+    "name:ita_x_preferred":[
+        "Berekua"
     ],
     "name:jpn_x_preferred":[
         "\u30b0\u30e9\u30f3\u30c9\u30fb\u30d9\u30a4"
@@ -61,8 +67,14 @@
     "name:por_x_preferred":[
         "Berakua"
     ],
+    "name:por_x_variant":[
+        "Berekua"
+    ],
     "name:ron_x_preferred":[
         "Berekua"
+    ],
+    "name:rus_x_preferred":[
+        "\u0411\u0435\u0440\u0435\u043a\u0443\u0430"
     ],
     "name:spa_x_preferred":[
         "Grand Bay"
@@ -109,7 +121,7 @@
         }
     ],
     "wof:id":1125873723,
-    "wof:lastmodified":1566581577,
+    "wof:lastmodified":1690874880,
     "wof:name":"Berekua",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/596/315/7/1125963157.geojson
+++ b/data/112/596/315/7/1125963157.geojson
@@ -49,6 +49,9 @@
     "name:ind_x_preferred":[
         "Salisbury"
     ],
+    "name:jpn_x_preferred":[
+        "\u30bd\u30fc\u30eb\u30ba\u30d9\u30ea\u30fc"
+    ],
     "name:kor_x_preferred":[
         "\uc194\uc988\ubca0\ub9ac"
     ],
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":1125963157,
-    "wof:lastmodified":1636497503,
+    "wof:lastmodified":1690874880,
     "wof:name":"Salisbury",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/179/087/421179087.geojson
+++ b/data/421/179/087/421179087.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Portsmouth"
+    ],
+    "name:aze_x_preferred":[
+        "Portsmut"
+    ],
     "name:ceb_x_preferred":[
         "Portsmouth"
     ],
@@ -40,6 +46,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05e4\u05d5\u05e8\u05d8\u05e1\u05de\u05d5\u05ea'"
+    ],
+    "name:ind_x_preferred":[
+        "Portsmouth"
     ],
     "name:ita_x_preferred":[
         "Portsmouth"
@@ -85,6 +94,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6a38\u8328\u8305\u592b"
+    ],
+    "name:zho_x_variant":[
+        "\u6734\u8328\u8305\u65af"
     ],
     "qs:gn_country":"DM",
     "qs:gn_fcode":"PPL",
@@ -135,7 +147,7 @@
         }
     ],
     "wof:id":421179087,
-    "wof:lastmodified":1566581575,
+    "wof:lastmodified":1690874877,
     "wof:name":"Portsmouth",
     "wof:parent_id":85670509,
     "wof:placetype":"locality",

--- a/data/421/196/673/421196673.geojson
+++ b/data/421/196/673/421196673.geojson
@@ -44,6 +44,9 @@
     "name:heb_x_preferred":[
         "\u05e1\u05d5\u05e4\u05e8\u05d9\u05d9\u05e8"
     ],
+    "name:ita_x_preferred":[
+        "Soufri\u00e8re"
+    ],
     "name:jpn_x_preferred":[
         "\u30b9\u30d5\u30ea\u30a8\u30fc\u30eb"
     ],
@@ -58,6 +61,9 @@
     ],
     "name:ron_x_preferred":[
         "Soufri\u00e8re"
+    ],
+    "name:rus_x_preferred":[
+        "\u0421\u0443\u0444\u0440\u0438\u0435\u0440"
     ],
     "name:spa_x_preferred":[
         "Soufri\u00e8re"
@@ -114,7 +120,7 @@
         }
     ],
     "wof:id":421196673,
-    "wof:lastmodified":1566581575,
+    "wof:lastmodified":1690874876,
     "wof:name":"Soufri\u00e8re",
     "wof:parent_id":85670519,
     "wof:placetype":"locality",

--- a/data/421/197/581/421197581.geojson
+++ b/data/421/197/581/421197581.geojson
@@ -44,6 +44,9 @@
     "name:ind_x_preferred":[
         "St. Joseph"
     ],
+    "name:ita_x_preferred":[
+        "Saint Joseph"
+    ],
     "name:jpn_x_preferred":[
         "\u30bb\u30f3\u30c8\u30fb\u30b8\u30e7\u30bc\u30d5"
     ],
@@ -62,11 +65,17 @@
     "name:ron_x_preferred":[
         "Saint Joseph"
     ],
+    "name:rus_x_preferred":[
+        "\u0421\u0435\u043d\u0442-\u0414\u0436\u043e\u0437\u0435\u0444"
+    ],
     "name:spa_x_preferred":[
         "Saint Joseph"
     ],
     "name:swe_x_preferred":[
         "Saint Joseph"
+    ],
+    "name:yue_x_preferred":[
+        "\u8056\u7d04\u745f\u592b"
     ],
     "name:zho_x_preferred":[
         "\u8056\u7d04\u745f\u592b"
@@ -112,7 +121,7 @@
         }
     ],
     "wof:id":421197581,
-    "wof:lastmodified":1636497502,
+    "wof:lastmodified":1690874877,
     "wof:name":"St. Joseph",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/199/981/421199981.geojson
+++ b/data/421/199/981/421199981.geojson
@@ -20,6 +20,9 @@
     "name:ceb_x_preferred":[
         "La Plaine"
     ],
+    "name:deu_x_preferred":[
+        "La Plaine"
+    ],
     "name:ell_x_preferred":[
         "\u039b\u03b1 \u03a0\u03bb\u03b1\u03b9\u03bd"
     ],
@@ -28,6 +31,9 @@
     ],
     "name:fra_x_preferred":[
         "La-Plaine"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30e9\u30fb\u30d7\u30ec\u30fc\u30cc"
     ],
     "name:nld_x_preferred":[
         "La Plaine"
@@ -88,7 +94,7 @@
         }
     ],
     "wof:id":421199981,
-    "wof:lastmodified":1566581575,
+    "wof:lastmodified":1690874877,
     "wof:name":"La Plaine",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/856/325/03/85632503.geojson
+++ b/data/856/325/03/85632503.geojson
@@ -29,6 +29,9 @@
     "mz:is_current":1,
     "mz:max_zoom":9.0,
     "mz:min_zoom":4.0,
+    "name:abk_x_preferred":[
+        "\u0414\u043e\u043c\u0438\u043d\u0438\u043a\u0430"
+    ],
     "name:afr_x_preferred":[
         "Dominica"
     ],
@@ -38,6 +41,9 @@
     "name:aka_x_preferred":[
         "D\u0254meneka"
     ],
+    "name:aka_x_variant":[
+        "Dominica"
+    ],
     "name:als_x_preferred":[
         "Dominica"
     ],
@@ -46,6 +52,15 @@
     ],
     "name:amh_x_variant":[
         "\u12f6\u121a\u1292\u12ab"
+    ],
+    "name:ami_x_preferred":[
+        "Dominica"
+    ],
+    "name:ang_x_preferred":[
+        "Dominica"
+    ],
+    "name:anp_x_preferred":[
+        "\u0921\u094b\u092e\u093f\u0928\u093f\u0915\u093e"
     ],
     "name:ara_x_preferred":[
         "\u062f\u0648\u0645\u064a\u0646\u064a\u0643\u0627"
@@ -77,6 +92,9 @@
     "name:bam_x_preferred":[
         "D\u0254miniki"
     ],
+    "name:ban_x_preferred":[
+        "Dominika"
+    ],
     "name:bar_x_preferred":[
         "Dominica"
     ],
@@ -98,6 +116,9 @@
     ],
     "name:bho_x_preferred":[
         "\u0921\u094b\u092e\u093f\u0928\u093f\u0915\u093e"
+    ],
+    "name:bis_x_preferred":[
+        "Dominika"
     ],
     "name:bod_x_preferred":[
         "\u0f4c\u0f7c\u0f0b\u0f58\u0f72\u0f0b\u0f53\u0f72\u0f0b\u0f40"
@@ -138,6 +159,9 @@
     "name:che_x_preferred":[
         "\u0414\u043e\u043c\u0438\u043d\u0438\u043a\u0430"
     ],
+    "name:chr_x_preferred":[
+        "\u13d9\u13bb\u13c2\u13a7"
+    ],
     "name:ckb_x_preferred":[
         "\u062f\u06c6\u0645\u06cc\u0646\u06cc\u06a9\u0627"
     ],
@@ -148,6 +172,9 @@
         "Dominika"
     ],
     "name:cym_x_preferred":[
+        "Dominica"
+    ],
+    "name:dag_x_preferred":[
         "Dominica"
     ],
     "name:dan_x_preferred":[
@@ -274,6 +301,9 @@
     "name:gom_x_preferred":[
         "\u0921\u0949\u092e\u093f\u0928\u093f\u0915\u093e"
     ],
+    "name:gpe_x_preferred":[
+        "Dominica"
+    ],
     "name:grn_x_preferred":[
         "Ndomin\u00edka"
     ],
@@ -363,6 +393,9 @@
     "name:kaa_x_preferred":[
         "Dominika"
     ],
+    "name:kab_x_preferred":[
+        "Duminik"
+    ],
     "name:kal_x_preferred":[
         "Dominica"
     ],
@@ -397,6 +430,9 @@
     "name:kur_x_preferred":[
         "\u062f\u06c6\u0645\u06cc\u0646\u06cc\u06a9\u0627"
     ],
+    "name:kur_x_variant":[
+        "Dom\u00een\u00eeka"
+    ],
     "name:lad_x_preferred":[
         "Dominika"
     ],
@@ -428,6 +464,9 @@
     "name:lit_x_preferred":[
         "Dominika"
     ],
+    "name:lld_x_preferred":[
+        "Dominica"
+    ],
     "name:lmo_x_preferred":[
         "Dominica"
     ],
@@ -443,6 +482,9 @@
     "name:lzh_x_preferred":[
         "\u591a\u7c73\u5c3c\u514b"
     ],
+    "name:mad_x_preferred":[
+        "Dominika"
+    ],
     "name:mal_x_preferred":[
         "\u0d21\u0d4a\u0d2e\u0d28\u0d3f\u0d15\u0d4d\u0d15"
     ],
@@ -455,11 +497,17 @@
     "name:mar_x_variant":[
         "\u0921\u094b\u092e\u093f\u0928\u093f\u0915\u093e"
     ],
+    "name:mdf_x_preferred":[
+        "\u0414\u043e\u043c\u0438\u043d\u0438\u043a\u0430"
+    ],
     "name:mhr_x_preferred":[
         "\u0414\u043e\u043c\u0438\u043d\u0438\u043a\u0435"
     ],
     "name:mhr_x_variant":[
         "\u0414\u043e\u043c\u0438\u043d\u0438\u043a\u0430"
+    ],
+    "name:min_x_preferred":[
+        "Dominika"
     ],
     "name:mkd_x_preferred":[
         "\u0414\u043e\u043c\u0438\u043d\u0438\u043a\u0430"
@@ -467,11 +515,23 @@
     "name:mlg_x_preferred":[
         "Dominika"
     ],
+    "name:mlg_x_variant":[
+        "D\u00f4minika"
+    ],
     "name:mlt_x_preferred":[
         "Dominika"
     ],
+    "name:mlt_x_variant":[
+        "Dominica"
+    ],
+    "name:mni_x_preferred":[
+        "\uabd7\uabe3\uabc3\uabe4\uabc5\uabe4\uabc0\uabe5"
+    ],
     "name:mon_x_preferred":[
         "\u0414\u043e\u043c\u0438\u043d\u0438\u043a\u0430"
+    ],
+    "name:mri_x_preferred":[
+        "Tominika"
     ],
     "name:mrj_x_preferred":[
         "\u0414\u043e\u043c\u0438\u043d\u0438\u043a\u0430"
@@ -584,11 +644,17 @@
     "name:que_x_preferred":[
         "Duminika"
     ],
+    "name:rmy_x_preferred":[
+        "Dominica"
+    ],
     "name:roh_x_preferred":[
         "Dominica"
     ],
     "name:ron_x_preferred":[
         "Dominica"
+    ],
+    "name:rue_x_preferred":[
+        "\u0414\u043e\u043c\u0438\u043d\u0438\u043a\u0430"
     ],
     "name:run_x_preferred":[
         "Dominika"
@@ -626,6 +692,9 @@
     "name:sgs_x_variant":[
         "Duom\u0117n\u0117\u0305ka"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1010\u1030\u101d\u103a\u1087\u1019\u102e\u1087\u107c\u102d\u1075"
+    ],
     "name:sin_x_preferred":[
         "\u0da9\u0ddc\u0db8\u0dd2\u0db1\u0dd2\u0d9a\u0dcf\u0dc0"
     ],
@@ -637,6 +706,12 @@
         "Dominika"
     ],
     "name:sme_x_preferred":[
+        "Dominica"
+    ],
+    "name:smn_x_preferred":[
+        "Dominica"
+    ],
+    "name:sms_x_preferred":[
         "Dominica"
     ],
     "name:sna_x_preferred":[
@@ -705,6 +780,9 @@
     "name:tat_x_preferred":[
         "\u0414\u043e\u043c\u0438\u043d\u0438\u043a\u0430"
     ],
+    "name:tay_x_preferred":[
+        "Dominica"
+    ],
     "name:tel_x_preferred":[
         "\u0c21\u0c4b\u0c2e\u0c46\u0c28\u0c3f\u0c15"
     ],
@@ -734,6 +812,9 @@
     ],
     "name:ton_x_preferred":[
         "Tominika"
+    ],
+    "name:trv_x_preferred":[
+        "Dominica"
     ],
     "name:tuk_x_preferred":[
         "Dominika"
@@ -1066,7 +1147,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636497500,
+    "wof:lastmodified":1690874874,
     "wof:name":"Dominica",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/704/95/85670495.geojson
+++ b/data/856/704/95/85670495.geojson
@@ -32,6 +32,9 @@
     "name:ara_x_preferred":[
         "\u0623\u0628\u0631\u0634\u064a\u0629 \u0633\u0627\u0646\u062a \u0623\u0646\u062f\u0631\u0648"
     ],
+    "name:ast_x_preferred":[
+        "Saint Andrew"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09a8\u09cd\u099f \u0986\u09a8\u09cd\u09a1\u09cd\u09b0\u09c1 \u09aa\u09be\u09b0\u09bf\u09b6"
     ],
@@ -73,6 +76,9 @@
     "name:fra_x_preferred":[
         "Saint-Andrew"
     ],
+    "name:frr_x_preferred":[
+        "Saint Andrew"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0a8f\u0aa8\u0acd\u0aa1\u0acd\u0ab0\u0ac1 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -100,6 +106,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc564\ub4dc\ub8e8 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc564\ub4dc\ub8e8\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentendr\u016b pagasts"
     ],
@@ -112,11 +121,17 @@
     "name:msa_x_preferred":[
         "Saint Andrew Parish"
     ],
+    "name:nan_x_preferred":[
+        "S\u00e8ng Andrew K\u00e0u-khu"
+    ],
     "name:nld_x_preferred":[
         "Saint Andrew"
     ],
     "name:nob_x_preferred":[
         "Saint Andrew prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Andrew Parish"
     ],
     "name:nor_x_preferred":[
         "Saint Andrew prestegjeld"
@@ -147,6 +162,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e0b\u0e19\u0e15\u0e4c \u0e41\u0e2d\u0e19\u0e14\u0e23\u0e34\u0e27 \u0e41\u0e1e\u0e23\u0e34\u0e0a"
+    ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e40\u0e0b\u0e19\u0e15\u0e4c\u0e41\u0e2d\u0e19\u0e14\u0e23\u0e39\u0e27\u0e4c"
     ],
     "name:tur_x_preferred":[
         "Saint Andrew Parish"
@@ -285,7 +303,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636497502,
+    "wof:lastmodified":1690874876,
     "wof:name":"Saint Andrew",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/704/99/85670499.geojson
+++ b/data/856/704/99/85670499.geojson
@@ -32,6 +32,9 @@
     "name:ara_x_preferred":[
         "\u0623\u0628\u0631\u0634\u064a\u0629 \u0627\u0644\u0642\u062f\u064a\u0633 \u062f\u064a\u0641\u064a\u062f"
     ],
+    "name:ast_x_preferred":[
+        "Saint David"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09a8\u09cd\u099f \u09a1\u09c7\u09ad\u09bf\u09a1 \u09aa\u09cd\u09af\u09be\u09b0\u09bf\u09b6"
     ],
@@ -73,6 +76,9 @@
     "name:fra_x_preferred":[
         "Saint-David"
     ],
+    "name:frr_x_preferred":[
+        "Saint David"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0aa1\u0ac7\u0ab5\u0abf\u0aa1 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -100,6 +106,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\ub370\uc774\ube44\ub4dc \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\ub370\uc774\ube44\ub4dc\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentdeivida pagasts"
     ],
@@ -112,11 +121,17 @@
     "name:msa_x_preferred":[
         "Saint David Parish"
     ],
+    "name:nan_x_preferred":[
+        "S\u00e8ng David K\u00e0u-khu"
+    ],
     "name:nld_x_preferred":[
         "Saint David"
     ],
     "name:nob_x_preferred":[
         "Saint David prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint David Parish"
     ],
     "name:nor_x_preferred":[
         "Saint David prestegjeld"
@@ -142,11 +157,17 @@
     "name:tam_x_preferred":[
         "\u0b9a\u0bc6\u0baf\u0bbf\u0ba9\u0bcd\u0b9f\u0bcd \u0b9f\u0bc7\u0bb5\u0bbf\u0b9f\u0bcd  \u0baa\u0bb0\u0bbf\u0bb7\u0bcd"
     ],
+    "name:tam_x_variant":[
+        "\u0b9a\u0bc6\u0baf\u0bbf\u0ba9\u0bcd\u0b9f\u0bcd \u0b9f\u0bc7\u0bb5\u0bbf\u0b9f\u0bcd \u0baa\u0bb0\u0bbf\u0bb7\u0bcd"
+    ],
     "name:tel_x_preferred":[
         "\u0c38\u0c46\u0c2f\u0c3f\u0c02\u0c1f\u0c4d \u0c21\u0c47\u0c35\u0c3f\u0c21\u0c4d \u0c2a\u0c3e\u0c30\u0c3f\u0c37\u0c4d"
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e0b\u0e19\u0e15\u0e4c\u0e40\u0e14\u0e27\u0e34\u0e14"
+    ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e40\u0e0b\u0e19\u0e15\u0e4c\u0e40\u0e14\u0e27\u0e34\u0e14"
     ],
     "name:tur_x_preferred":[
         "Saint David Parish"
@@ -285,7 +306,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636497502,
+    "wof:lastmodified":1690874876,
     "wof:name":"Saint David",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/705/03/85670503.geojson
+++ b/data/856/705/03/85670503.geojson
@@ -61,6 +61,9 @@
         "St. George",
         "Saint George Parish"
     ],
+    "name:epo_x_preferred":[
+        "Paro\u0125o Sankta Georgo"
+    ],
     "name:fas_x_preferred":[
         "\u0633\u0646\u062a \u062c\u0648\u0631\u062c"
     ],
@@ -73,6 +76,9 @@
     ],
     "name:fra_x_preferred":[
         "Saint-George"
+    ],
+    "name:frr_x_preferred":[
+        "Saint George"
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0a9c\u0acd\u0aaf\u0acb\u0ab0\u0acd\u0a9c \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
@@ -101,6 +107,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc870\uc9c0 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc870\uc9c0\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentd\u017eord\u017ea pagasts"
     ],
@@ -113,11 +122,17 @@
     "name:msa_x_preferred":[
         "Saint George Parish"
     ],
+    "name:nan_x_preferred":[
+        "S\u00e8ng George K\u00e0u-khu"
+    ],
     "name:nld_x_preferred":[
         "Saint George"
     ],
     "name:nob_x_preferred":[
         "Saint George prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint George Parish"
     ],
     "name:nor_x_preferred":[
         "Saint George prestegjeld"
@@ -149,6 +164,9 @@
     "name:tha_x_preferred":[
         "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e0b\u0e32\u0e21\u0e32\u0e19\u0e32"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e40\u0e0b\u0e19\u0e15\u0e4c\u0e08\u0e2d\u0e23\u0e4c\u0e08"
+    ],
     "name:tur_x_preferred":[
         "Saint George Parish"
     ],
@@ -166,6 +184,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8056\u55ac\u6cbb\u5802\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u8056\u55ac\u6cbb\u5340"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DMA",
@@ -286,7 +307,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636497501,
+    "wof:lastmodified":1690874874,
     "wof:name":"Saint George",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/705/09/85670509.geojson
+++ b/data/856/705/09/85670509.geojson
@@ -32,6 +32,12 @@
     "name:ara_x_preferred":[
         "\u0623\u0628\u0631\u0634\u064a\u0629 \u0627\u0644\u0642\u062f\u064a\u0633 \u062c\u0648\u0646"
     ],
+    "name:ast_x_preferred":[
+        "Saint John"
+    ],
+    "name:aze_x_preferred":[
+        "Sent-Con s\u0259mti"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09a8\u09cd\u099f \u099c\u09a8 \u09aa\u09cd\u09af\u09be\u09b0\u09bf\u09b6"
     ],
@@ -76,6 +82,9 @@
     "name:fra_x_variant":[
         "Saint John"
     ],
+    "name:frr_x_preferred":[
+        "Saint John"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0a82\u0a9f \u0a9c\u0acd\u0ab9\u0acb\u0aa8 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -97,6 +106,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc874 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc874\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentd\u017eona pagasts"
     ],
@@ -109,11 +121,17 @@
     "name:msa_x_preferred":[
         "Saint John Parish"
     ],
+    "name:nan_x_preferred":[
+        "S\u00e8ng John K\u00e0u-khu"
+    ],
     "name:nld_x_preferred":[
         "Saint John"
     ],
     "name:nob_x_preferred":[
         "Saint John prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint John Parish"
     ],
     "name:nor_x_preferred":[
         "Saint John prestegjeld"
@@ -145,6 +163,9 @@
     "name:tha_x_preferred":[
         "\u0e40\u0e0b\u0e19\u0e15\u0e4c \u0e08\u0e2d\u0e19 \u0e41\u0e1e\u0e23\u0e34\u0e0a"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e40\u0e0b\u0e19\u0e15\u0e4c\u0e08\u0e2d\u0e2b\u0e4c\u0e19"
+    ],
     "name:tur_x_preferred":[
         "Saint John Parish"
     ],
@@ -171,6 +192,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8056\u7d04\u7ff0\u5802\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u8056\u7d04\u7ff0\u5340"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DMA",
@@ -291,7 +315,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636497501,
+    "wof:lastmodified":1690874875,
     "wof:name":"Saint John",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/705/11/85670511.geojson
+++ b/data/856/705/11/85670511.geojson
@@ -32,6 +32,9 @@
     "name:ara_x_preferred":[
         "\u0623\u0628\u0631\u0634\u064a\u0629 \u0627\u0644\u0642\u062f\u064a\u0633 \u062c\u0648\u0632\u064a\u0641"
     ],
+    "name:ast_x_preferred":[
+        "Saint Joseph"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09a8\u09cd\u099f \u099c\u09cb\u09b8\u09c7\u09ab \u09aa\u09cd\u09af\u09be\u09b0\u09bf\u09b6"
     ],
@@ -73,6 +76,9 @@
     "name:fra_x_preferred":[
         "Saint-Joseph"
     ],
+    "name:frr_x_preferred":[
+        "Saint Joseph"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0a9c\u0acb\u0ab8\u0ac7\u0aab \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -100,6 +106,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc870\uc9c0\ud504 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc870\uc9c0\ud504\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentd\u017eozefa pagasts"
     ],
@@ -112,11 +121,17 @@
     "name:msa_x_preferred":[
         "Saint Joseph Parish"
     ],
+    "name:nan_x_preferred":[
+        "S\u00e8ng Joseph K\u00e0u-khu"
+    ],
     "name:nld_x_preferred":[
         "Saint Joseph"
     ],
     "name:nob_x_preferred":[
         "Saint Joseph prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Joseph Parish"
     ],
     "name:nor_x_preferred":[
         "Saint Joseph prestegjeld"
@@ -129,6 +144,9 @@
     ],
     "name:rus_x_preferred":[
         "\u041f\u0440\u0445\u043e\u0434 \u0421\u0435\u043d\u0442-\u0414\u0436\u043e\u0437\u0435\u0444"
+    ],
+    "name:rus_x_variant":[
+        "\u041f\u0440\u0438\u0445\u043e\u0434 \u0421\u0435\u043d\u0442-\u0414\u0436\u043e\u0437\u0435\u0444"
     ],
     "name:sin_x_preferred":[
         "\u0dc1\u0dcf\u0db1\u0dca\u0dad \u0da2\u0ddd\u0dc1\u0db4\u0dca \u0db4\u0dca\u200d\u0dbb\u0dcf\u0db1\u0dca\u0dad\u0dba"
@@ -147,6 +165,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e0b\u0e19\u0e15\u0e4c \u0e42\u0e08\u0e40\u0e0b\u0e1f \u0e41\u0e1e\u0e23\u0e34\u0e0a"
+    ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e40\u0e0b\u0e19\u0e15\u0e4c\u0e42\u0e22\u0e40\u0e0b\u0e1f"
     ],
     "name:tur_x_preferred":[
         "Sain Joseph Parish"
@@ -285,7 +306,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636497501,
+    "wof:lastmodified":1690874874,
     "wof:name":"Saint Joseph",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/705/15/85670515.geojson
+++ b/data/856/705/15/85670515.geojson
@@ -73,6 +73,9 @@
     "name:fra_x_preferred":[
         "Saint-Luke"
     ],
+    "name:frr_x_preferred":[
+        "Saint Luke"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0ab2\u0acd\u0aaf\u0ac1\u0a95 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -100,6 +103,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\ub8e8\ud06c \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\ub8e8\ud06c\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentl\u016bka pagasts"
     ],
@@ -112,11 +118,17 @@
     "name:msa_x_preferred":[
         "Saint Luke Parish"
     ],
+    "name:nan_x_preferred":[
+        "S\u00e8ng Luke K\u00e0u-khu"
+    ],
     "name:nld_x_preferred":[
         "Saint Luke"
     ],
     "name:nob_x_preferred":[
         "Saint Luke prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Luke Parish"
     ],
     "name:nor_x_preferred":[
         "Saint Luke prestegjeld"
@@ -148,6 +160,9 @@
     "name:tha_x_preferred":[
         "\u0e15\u0e33\u0e1a\u0e25\u0e40\u0e0b\u0e19\u0e25\u0e38\u0e04"
     ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e40\u0e0b\u0e19\u0e15\u0e4c\u0e25\u0e39\u0e49\u0e01"
+    ],
     "name:tur_x_preferred":[
         "Saint Luke Parish"
     ],
@@ -163,8 +178,14 @@
     "name:vie_x_preferred":[
         "Gi\u00e1o x\u1ee9 Saint Luke"
     ],
+    "name:wuu_x_preferred":[
+        "\u5723\u5362\u514b\u533a"
+    ],
     "name:zho_x_preferred":[
         "\u8056\u76e7\u514b\u5802\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u8056\u76e7\u514b\u5340"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"DMA",
@@ -285,7 +306,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636497502,
+    "wof:lastmodified":1690874876,
     "wof:name":"Saint Luke",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/705/19/85670519.geojson
+++ b/data/856/705/19/85670519.geojson
@@ -73,6 +73,9 @@
     "name:fra_x_preferred":[
         "Saint-Mark"
     ],
+    "name:frr_x_preferred":[
+        "Saint Mark"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0aae\u0abe\u0ab0\u0acd\u0a95 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -100,6 +103,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\ub9c8\ud06c \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\ub9c8\ud06c\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentmarka pagasts"
     ],
@@ -112,11 +118,17 @@
     "name:msa_x_preferred":[
         "Saint Mark Parish"
     ],
+    "name:nan_x_preferred":[
+        "S\u00e8ng Mark K\u00e0u-khu"
+    ],
     "name:nld_x_preferred":[
         "Saint Mark"
     ],
     "name:nob_x_preferred":[
         "Saint Mark prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Mark Parish"
     ],
     "name:nor_x_preferred":[
         "Saint Mark prestegjeld"
@@ -147,6 +159,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e0b\u0e19\u0e15\u0e4c\u0e21\u0e32\u0e23\u0e4c\u0e04"
+    ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e40\u0e0b\u0e19\u0e15\u0e4c\u0e21\u0e32\u0e23\u0e4c\u0e01"
     ],
     "name:tur_x_preferred":[
         "Saint Mark Parish"
@@ -285,7 +300,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1642551817,
+    "wof:lastmodified":1690874875,
     "wof:name":"Saint Mark",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/705/21/85670521.geojson
+++ b/data/856/705/21/85670521.geojson
@@ -73,6 +73,9 @@
     "name:fra_x_preferred":[
         "Saint-Patrick"
     ],
+    "name:frr_x_preferred":[
+        "Saint Patrick"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0aaa\u0ac7\u0a9f\u0acd\u0ab0\u0abf\u0a95 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -100,6 +103,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\ud328\ud2b8\ub9ad \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\ud328\ud2b8\ub9ad\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentpatrika pagasts"
     ],
@@ -112,11 +118,17 @@
     "name:msa_x_preferred":[
         "Saint Patrick Parish"
     ],
+    "name:nan_x_preferred":[
+        "S\u00e8ng Patrick K\u00e0u-khu"
+    ],
     "name:nld_x_preferred":[
         "Saint Patrick"
     ],
     "name:nob_x_preferred":[
         "Saint Patrick prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Patrick Parish"
     ],
     "name:nor_x_preferred":[
         "Saint Patrick prestegjeld"
@@ -147,6 +159,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e0b\u0e19\u0e15\u0e4c \u0e41\u0e1e\u0e17\u0e23\u0e34\u0e04 \u0e41\u0e1e\u0e23\u0e34\u0e0a"
+    ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e40\u0e0b\u0e19\u0e15\u0e4c\u0e41\u0e1e\u0e17\u0e23\u0e34\u0e01"
     ],
     "name:tur_x_preferred":[
         "Saint Patrick Parish"
@@ -285,7 +300,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636497501,
+    "wof:lastmodified":1690874875,
     "wof:name":"Saint Patrick",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/705/27/85670527.geojson
+++ b/data/856/705/27/85670527.geojson
@@ -73,6 +73,9 @@
     "name:fra_x_preferred":[
         "Saint-Paul"
     ],
+    "name:frr_x_preferred":[
+        "Saint Paul"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0a87\u0aa8\u0acd\u0a9f \u0aaa\u0acc\u0ab2 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -94,6 +97,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\ud3f4 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\ud3f4\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentpola pagasts"
     ],
@@ -106,11 +112,17 @@
     "name:msa_x_preferred":[
         "Saint Paul Parish"
     ],
+    "name:nan_x_preferred":[
+        "S\u00e8ng Paul K\u00e0u-khu"
+    ],
     "name:nld_x_preferred":[
         "Saint Paul"
     ],
     "name:nob_x_preferred":[
         "Saint Paul prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Paul Parish"
     ],
     "name:nor_x_preferred":[
         "Saint Paul prestegjeld"
@@ -141,6 +153,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e0b\u0e19\u0e15\u0e4c\u0e1b\u0e2d\u0e25"
+    ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e40\u0e0b\u0e19\u0e15\u0e4c\u0e1e\u0e2d\u0e25"
     ],
     "name:tur_x_preferred":[
         "Saint Paul Parish"
@@ -282,7 +297,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636497501,
+    "wof:lastmodified":1690874874,
     "wof:name":"Saint Paul",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/705/31/85670531.geojson
+++ b/data/856/705/31/85670531.geojson
@@ -32,6 +32,9 @@
     "name:ara_x_preferred":[
         "\u0623\u0628\u0631\u0634\u064a\u0629 \u0627\u0644\u0642\u062f\u064a\u0633 \u0628\u064a\u062a\u0631"
     ],
+    "name:ast_x_preferred":[
+        "Saint Peter"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09a8\u09cd\u099f \u09aa\u09bf\u099f\u09be\u09b0 \u09aa\u09cd\u09af\u09be\u09b0\u09bf\u09b6"
     ],
@@ -73,6 +76,9 @@
     "name:fra_x_preferred":[
         "Saint-Peter"
     ],
+    "name:frr_x_preferred":[
+        "Saint Peter"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0aaa\u0ac0\u0a9f\u0ab0 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -94,6 +100,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\ud53c\ud130 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\ud53c\ud130\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentp\u012btera pagasts"
     ],
@@ -106,11 +115,17 @@
     "name:msa_x_preferred":[
         "Saint Peter Parish"
     ],
+    "name:nan_x_preferred":[
+        "S\u00e8ng Peter K\u00e0u-khu"
+    ],
     "name:nld_x_preferred":[
         "Saint Peter"
     ],
     "name:nob_x_preferred":[
         "Saint Peter prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Peter Parish"
     ],
     "name:nor_x_preferred":[
         "Saint Peter prestegjeld"
@@ -141,6 +156,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e25\u0e38\u0e21\u0e1e\u0e34\u0e19\u0e35\u0e27\u0e31\u0e19"
+    ],
+    "name:tha_x_variant":[
+        "\u0e40\u0e02\u0e15\u0e40\u0e0b\u0e19\u0e15\u0e4c\u0e1b\u0e35\u0e40\u0e15\u0e2d\u0e23\u0e4c"
     ],
     "name:tur_x_preferred":[
         "Saint Peter Parish"
@@ -288,7 +306,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636497502,
+    "wof:lastmodified":1690874875,
     "wof:name":"Saint Peter",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/890/420/161/890420161.geojson
+++ b/data/890/420/161/890420161.geojson
@@ -37,6 +37,9 @@
     "name:heb_x_preferred":[
         "\u05e7\u05d5\u05dc\u05d9\u05d4\u05d5"
     ],
+    "name:ita_x_preferred":[
+        "Colihaut"
+    ],
     "name:jpn_x_preferred":[
         "\u30b3\u30ea\u30aa\u30fc"
     ],
@@ -51,6 +54,9 @@
     ],
     "name:ron_x_preferred":[
         "Colihaut"
+    ],
+    "name:rus_x_preferred":[
+        "\u041a\u043e\u043b\u0438\u043e"
     ],
     "name:spa_x_preferred":[
         "Colihaut"
@@ -95,7 +101,7 @@
         }
     ],
     "wof:id":890420161,
-    "wof:lastmodified":1566581576,
+    "wof:lastmodified":1690874878,
     "wof:name":"Colihaut",
     "wof:parent_id":85670531,
     "wof:placetype":"locality",

--- a/data/890/429/317/890429317.geojson
+++ b/data/890/429/317/890429317.geojson
@@ -37,6 +37,9 @@
     "name:heb_x_preferred":[
         "\u05e4\u05d5\u05e0\u05d8 \u05e7\u05e1\u05d4"
     ],
+    "name:ita_x_preferred":[
+        "Pont Cass\u00e9"
+    ],
     "name:jpn_x_preferred":[
         "\u30dd\u30f3\u30fb\u30ab\u30b9"
     ],
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":890429317,
-    "wof:lastmodified":1566581576,
+    "wof:lastmodified":1690874877,
     "wof:name":"Pont Cass\u00e9",
     "wof:parent_id":85670527,
     "wof:placetype":"locality",

--- a/data/890/429/577/890429577.geojson
+++ b/data/890/429/577/890429577.geojson
@@ -40,6 +40,9 @@
     "name:heb_x_preferred":[
         "\u05e4\u05d5\u05d9\u05e0\u05d8 \u05de\u05d9\u05e9\u05dc"
     ],
+    "name:ita_x_preferred":[
+        "Pointe Michel"
+    ],
     "name:jpn_x_preferred":[
         "\u30dd\u30ef\u30f3\u30c8\u30fb\u30de\u30a4\u30b1\u30eb"
     ],
@@ -54,6 +57,9 @@
     ],
     "name:ron_x_preferred":[
         "Pointe Michel"
+    ],
+    "name:rus_x_preferred":[
+        "\u041f\u0443\u044d\u043d\u0442-\u041c\u0438\u0448\u0435\u043b\u044c"
     ],
     "name:spa_x_preferred":[
         "Pointe Michel"
@@ -100,7 +106,7 @@
         }
     ],
     "wof:id":890429577,
-    "wof:lastmodified":1566581576,
+    "wof:lastmodified":1690874878,
     "wof:name":"Pointe Michel",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/429/579/890429579.geojson
+++ b/data/890/429/579/890429579.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Mahaut"
     ],
+    "name:deu_x_preferred":[
+        "Mahaut"
+    ],
     "name:ell_x_preferred":[
         "\u039c\u03b1\u03ce"
     ],
@@ -48,6 +51,9 @@
     ],
     "name:ron_x_preferred":[
         "Mahaut"
+    ],
+    "name:rus_x_preferred":[
+        "\u041c\u0430\u043e"
     ],
     "name:swe_x_preferred":[
         "Mahaut"
@@ -82,7 +88,7 @@
         }
     ],
     "wof:id":890429579,
-    "wof:lastmodified":1566581576,
+    "wof:lastmodified":1690874878,
     "wof:name":"Mahaut",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/434/919/890434919.geojson
+++ b/data/890/434/919/890434919.geojson
@@ -34,6 +34,9 @@
     "name:fra_x_preferred":[
         "Woodford Hill River"
     ],
+    "name:gle_x_preferred":[
+        "Abhainn Woodford Hill"
+    ],
     "name:spa_x_preferred":[
         "Woodford Hill River"
     ],
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":890434919,
-    "wof:lastmodified":1566581577,
+    "wof:lastmodified":1690874879,
     "wof:name":"Woodford Hill",
     "wof:parent_id":85670495,
     "wof:placetype":"locality",

--- a/data/890/434/921/890434921.geojson
+++ b/data/890/434/921/890434921.geojson
@@ -22,6 +22,9 @@
     "name:ceb_x_preferred":[
         "Wesley"
     ],
+    "name:deu_x_preferred":[
+        "Wesley"
+    ],
     "name:ell_x_preferred":[
         "\u039f\u03c5\u03ad\u03c3\u03bb\u03b9"
     ],
@@ -34,6 +37,9 @@
     "name:heb_x_preferred":[
         "\u05d5\u05e1\u05dc\u05d9"
     ],
+    "name:ita_x_preferred":[
+        "Wesley"
+    ],
     "name:jpn_x_preferred":[
         "\u30a6\u30a7\u30ba\u30ea\u30fc"
     ],
@@ -45,6 +51,9 @@
     ],
     "name:ron_x_preferred":[
         "Wesley"
+    ],
+    "name:rus_x_preferred":[
+        "\u0423\u044d\u0441\u043b\u0438"
     ],
     "name:spa_x_preferred":[
         "Wesley"
@@ -89,7 +98,7 @@
         }
     ],
     "wof:id":890434921,
-    "wof:lastmodified":1566581577,
+    "wof:lastmodified":1690874879,
     "wof:name":"Wesley",
     "wof:parent_id":85670495,
     "wof:placetype":"locality",

--- a/data/890/434/925/890434925.geojson
+++ b/data/890/434/925/890434925.geojson
@@ -121,6 +121,9 @@
     "name:ita_x_preferred":[
         "Marigot"
     ],
+    "name:jpn_x_preferred":[
+        "\u30de\u30ea\u30b4"
+    ],
     "name:kon_x_preferred":[
         "Marigot"
     ],
@@ -263,7 +266,7 @@
         }
     ],
     "wof:id":890434925,
-    "wof:lastmodified":1566581577,
+    "wof:lastmodified":1690874879,
     "wof:name":"Marigot",
     "wof:parent_id":85670495,
     "wof:placetype":"locality",

--- a/data/890/434/927/890434927.geojson
+++ b/data/890/434/927/890434927.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "Castle Bruce"
+    ],
     "name:ceb_x_preferred":[
         "Castle Bruce"
     ],
@@ -37,6 +40,9 @@
     "name:fra_x_preferred":[
         "Castle-Bruce"
     ],
+    "name:jpn_x_preferred":[
+        "\u30ab\u30c3\u30b9\u30eb\u30fb\u30d6\u30eb\u30fc\u30b9"
+    ],
     "name:nld_x_preferred":[
         "Castle Bruce"
     ],
@@ -49,11 +55,17 @@
     "name:ron_x_preferred":[
         "Castle Bruce"
     ],
+    "name:rus_x_preferred":[
+        "\u041a\u0430\u0441\u043b-\u0411\u0440\u044e\u0441"
+    ],
     "name:spa_x_preferred":[
         "Castle Bruce"
     ],
     "name:swe_x_preferred":[
         "Castle Bruce"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e04\u0e32\u0e2a\u0e40\u0e0b\u0e34\u0e25\u0e1a\u0e23\u0e39\u0e0b"
     ],
     "name:zho_x_preferred":[
         "\u5361\u65af\u723e\u5e03\u9b6f\u65af"
@@ -89,7 +101,7 @@
         }
     ],
     "wof:id":890434927,
-    "wof:lastmodified":1566581577,
+    "wof:lastmodified":1690874879,
     "wof:name":"Castle Bruce",
     "wof:parent_id":85670499,
     "wof:placetype":"locality",

--- a/data/890/434/929/890434929.geojson
+++ b/data/890/434/929/890434929.geojson
@@ -37,6 +37,9 @@
     "name:fra_x_preferred":[
         "Calibishie"
     ],
+    "name:jpn_x_preferred":[
+        "\u30ab\u30ea\u30d3\u30b7"
+    ],
     "name:nld_x_preferred":[
         "Calibishie"
     ],
@@ -49,6 +52,9 @@
     "name:ron_x_preferred":[
         "Calibishie"
     ],
+    "name:rus_x_preferred":[
+        "\u041a\u0430\u043b\u0438\u0431\u0438\u0448\u0438"
+    ],
     "name:spa_x_preferred":[
         "Calibishie"
     ],
@@ -60,6 +66,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5361\u5229\u7562\u65af\u8036"
+    ],
+    "name:zho_x_variant":[
+        "\u5361\u5229\u6bd4\u5e0c"
     ],
     "qs:name":"Calibishie",
     "qs:photos_9r":0,
@@ -92,7 +101,7 @@
         }
     ],
     "wof:id":890434929,
-    "wof:lastmodified":1566581577,
+    "wof:lastmodified":1690874879,
     "wof:name":"Calibishie",
     "wof:parent_id":85670495,
     "wof:placetype":"locality",

--- a/data/890/442/101/890442101.geojson
+++ b/data/890/442/101/890442101.geojson
@@ -30,7 +30,19 @@
     "name:ara_x_preferred":[
         "\u0631\u0648\u0633\u0648"
     ],
+    "name:arg_x_preferred":[
+        "Roseau"
+    ],
+    "name:ary_x_preferred":[
+        "\u0631\u0648\u0633\u0648"
+    ],
+    "name:arz_x_preferred":[
+        "\u0631\u0648\u0633\u0648"
+    ],
     "name:ast_x_preferred":[
+        "Roseau"
+    ],
+    "name:avk_x_preferred":[
         "Roseau"
     ],
     "name:aym_x_preferred":[
@@ -39,8 +51,14 @@
     "name:aze_x_preferred":[
         "Rozo"
     ],
+    "name:ban_x_preferred":[
+        "Roseau"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0420\u0430\u0437\u043e"
+    ],
+    "name:bel_x_variant":[
+        "\u0420\u0430\u0437\u043e"
     ],
     "name:ben_x_preferred":[
         "\u09b0\u09cb\u09b8\u09c7\u0989"
@@ -103,6 +121,9 @@
         "Roseau"
     ],
     "name:fra_x_preferred":[
+        "Roseau"
+    ],
+    "name:frr_x_preferred":[
         "Roseau"
     ],
     "name:fry_x_preferred":[
@@ -174,14 +195,23 @@
     "name:lav_x_preferred":[
         "Rozo"
     ],
+    "name:lij_x_preferred":[
+        "Roseau"
+    ],
     "name:lit_x_preferred":[
         "Rozo"
     ],
     "name:lmo_x_preferred":[
         "Roseau"
     ],
+    "name:mal_x_preferred":[
+        "\u0d31\u0d4a\u0d38\u0d57"
+    ],
     "name:mar_x_preferred":[
         "\u0930\u0941\u0938\u093e\u0909"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0420\u043e\u0437\u043e"
     ],
     "name:mkd_x_preferred":[
         "\u0420\u043e\u0437\u043e"
@@ -234,6 +264,9 @@
     "name:por_x_preferred":[
         "Roseau"
     ],
+    "name:pus_x_preferred":[
+        "\u0631\u0648\u0633\u0648"
+    ],
     "name:ron_x_preferred":[
         "Roseau"
     ],
@@ -261,6 +294,9 @@
     "name:sqi_x_preferred":[
         "Roseau"
     ],
+    "name:srd_x_preferred":[
+        "Roseau"
+    ],
     "name:srp_x_preferred":[
         "\u0420\u043e\u0437\u043e"
     ],
@@ -270,8 +306,14 @@
     "name:swe_x_preferred":[
         "Roseau"
     ],
+    "name:szl_x_preferred":[
+        "Roseau"
+    ],
     "name:tam_x_preferred":[
         "\u0b89\u0bb1\u0bca\u0b9a\u0bcb"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0420\u043e\u0437\u043e"
     ],
     "name:tgl_x_preferred":[
         "Roseau"
@@ -281,6 +323,9 @@
     ],
     "name:tur_x_preferred":[
         "Roseau"
+    ],
+    "name:udm_x_preferred":[
+        "\u0420\u043e\u0437\u043e"
     ],
     "name:ukr_x_preferred":[
         "\u0420\u043e\u0437\u043e"
@@ -302,6 +347,9 @@
     ],
     "name:war_x_preferred":[
         "Roseau"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10e0\u10dd\u10d6\u10dd"
     ],
     "name:yor_x_preferred":[
         "Roseau"
@@ -453,7 +501,7 @@
         }
     ],
     "wof:id":890442101,
-    "wof:lastmodified":1636497503,
+    "wof:lastmodified":1690874878,
     "wof:name":"Roseau",
     "wof:parent_id":85670503,
     "wof:placetype":"locality",

--- a/data/890/455/323/890455323.geojson
+++ b/data/890/455/323/890455323.geojson
@@ -22,6 +22,9 @@
     "name:ceb_x_preferred":[
         "Rosalie"
     ],
+    "name:deu_x_preferred":[
+        "Rosalie"
+    ],
     "name:ell_x_preferred":[
         "\u03a1\u03bf\u03b6\u03b1\u03bb\u03af"
     ],
@@ -33,6 +36,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05e8\u05d5\u05d6\u05dc\u05d9"
+    ],
+    "name:ita_x_preferred":[
+        "Rosalie"
     ],
     "name:jpn_x_preferred":[
         "\u30ed\u30b6\u30ea\u30fc"
@@ -48,6 +54,9 @@
     ],
     "name:ron_x_preferred":[
         "Rosalie"
+    ],
+    "name:rus_x_preferred":[
+        "\u0420\u043e\u0437\u0430\u043b\u0438"
     ],
     "name:swe_x_preferred":[
         "Rosalie"
@@ -86,7 +95,7 @@
         }
     ],
     "wof:id":890455323,
-    "wof:lastmodified":1566581575,
+    "wof:lastmodified":1690874877,
     "wof:name":"Rosalie",
     "wof:parent_id":85670499,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.