### PR TITLE
dm concordances, placetype local, and more

### DIFF
--- a/data/856/325/03/85632503.geojson
+++ b/data/856/325/03/85632503.geojson
@@ -1117,6 +1117,7 @@
         "hasc:id":"DM",
         "icao:code":"J7",
         "ioc:id":"DMA",
+        "iso:code":"DM",
         "itu:id":"DMA",
         "loc:id":"n50065763",
         "m49:code":"212",
@@ -1131,6 +1132,7 @@
         "wk:page":"Dominica",
         "wmo:id":"DO"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DM",
     "wof:country_alpha3":"DMA",
     "wof:geom_alt":[
@@ -1151,7 +1153,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639668,
+    "wof:lastmodified":1695881328,
     "wof:name":"Dominica",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/704/95/85670495.geojson
+++ b/data/856/704/95/85670495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016702,
-    "geom:area_square_m":198980471.05285,
+    "geom:area_square_m":198979994.994789,
     "geom:bbox":"-61.449211,15.444872,-61.268625,15.633084",
     "geom:latitude":15.535794,
     "geom:longitude":-61.354701,
@@ -281,14 +281,16 @@
         "gn:id":3575632,
         "gp:id":2345161,
         "hasc:id":"DM.AN",
+        "iso:code":"DM-02",
         "iso:id":"DM-02",
         "qs_pg:id":219540,
         "unlc:id":"DM-02",
         "wd:id":"Q732322",
         "wk:page":"Saint Andrew Parish, Dominica"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DM",
-    "wof:geomhash":"328e001c7a628ea3ad68ce2120d5a1ef",
+    "wof:geomhash":"609d23f6d4d5fe49b4b0e36f60a334c4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -303,7 +305,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690874876,
+    "wof:lastmodified":1695884852,
     "wof:name":"Saint Andrew",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/704/99/85670499.geojson
+++ b/data/856/704/99/85670499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009879,
-    "geom:area_square_m":117771342.192585,
+    "geom:area_square_m":117771186.074187,
     "geom:bbox":"-61.334571,15.316662,-61.249257,15.509914",
     "geom:latitude":15.399591,
     "geom:longitude":-61.28866,
@@ -284,14 +284,16 @@
         "gn:id":3575630,
         "gp:id":2345162,
         "hasc:id":"DM.DA",
+        "iso:code":"DM-03",
         "iso:id":"DM-03",
         "qs_pg:id":894870,
         "unlc:id":"DM-03",
         "wd:id":"Q1431129",
         "wk:page":"Saint David Parish, Dominica"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DM",
-    "wof:geomhash":"7a935b2c056d618d59173397662b6e06",
+    "wof:geomhash":"c01cd7c96d3b5bb3af431ba8837ac187",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -306,7 +308,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690874876,
+    "wof:lastmodified":1695884852,
     "wof:name":"Saint David",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/705/03/85670503.geojson
+++ b/data/856/705/03/85670503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004504,
-    "geom:area_square_m":53723258.920105,
+    "geom:area_square_m":53723588.590648,
     "geom:bbox":"-61.393599,15.253798,-61.30416,15.345524",
     "geom:latitude":15.303056,
     "geom:longitude":-61.347586,
@@ -285,14 +285,16 @@
         "gn:id":3575628,
         "gp:id":2345163,
         "hasc:id":"DM.GO",
+        "iso:code":"DM-04",
         "iso:id":"DM-04",
         "qs_pg:id":894871,
         "unlc:id":"DM-04",
         "wd:id":"Q617801",
         "wk:page":"Saint George Parish, Dominica"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DM",
-    "wof:geomhash":"cafc7dc1a72e559d0979ae9c28de5fb0",
+    "wof:geomhash":"8caca9e798ff534bfe08998378377ec0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -307,7 +309,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690874874,
+    "wof:lastmodified":1695884852,
     "wof:name":"Saint George",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/705/09/85670509.geojson
+++ b/data/856/705/09/85670509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005481,
-    "geom:area_square_m":65282760.900775,
+    "geom:area_square_m":65283255.038797,
     "geom:bbox":"-61.488922,15.503008,-61.407719,15.633857",
     "geom:latitude":15.566384,
     "geom:longitude":-61.449686,
@@ -293,14 +293,16 @@
         "gn:id":3575626,
         "gp:id":2345164,
         "hasc:id":"DM.JN",
+        "iso:code":"DM-05",
         "iso:id":"DM-05",
         "qs_pg:id":894872,
         "unlc:id":"DM-05",
         "wd:id":"Q1476285",
         "wk:page":"Saint John Parish, Dominica"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DM",
-    "wof:geomhash":"124d1b252770218939facdabd05793df",
+    "wof:geomhash":"092f7a74ef167dfd0a0dac8c81298c3e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -315,7 +317,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690874875,
+    "wof:lastmodified":1695884852,
     "wof:name":"Saint John",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/705/11/85670511.geojson
+++ b/data/856/705/11/85670511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009687,
-    "geom:area_square_m":115463094.906373,
+    "geom:area_square_m":115462917.05004,
     "geom:bbox":"-61.455329,15.389345,-61.317363,15.494455",
     "geom:latitude":15.441453,
     "geom:longitude":-61.385752,
@@ -284,14 +284,16 @@
         "gn:id":3575625,
         "gp:id":2345165,
         "hasc:id":"DM.JH",
+        "iso:code":"DM-06",
         "iso:id":"DM-06",
         "qs_pg:id":890045,
         "unlc:id":"DM-06",
         "wd:id":"Q1476302",
         "wk:page":"Saint Joseph Parish, Dominica"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DM",
-    "wof:geomhash":"c58821a8e2a31487b3bd7c22ab3fd51b",
+    "wof:geomhash":"2c5950c1d24d1a8787f91618c647a8ee",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -306,7 +308,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690874874,
+    "wof:lastmodified":1695884852,
     "wof:name":"Saint Joseph",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/705/15/85670515.geojson
+++ b/data/856/705/15/85670515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00029,
-    "geom:area_square_m":3462520.473507,
+    "geom:area_square_m":3462504.965599,
     "geom:bbox":"-61.373179,15.235884,-61.355655,15.260347",
     "geom:latitude":15.248327,
     "geom:longitude":-61.365725,
@@ -284,14 +284,16 @@
         "gn:id":3575622,
         "gp:id":2345166,
         "hasc:id":"DM.LU",
+        "iso:code":"DM-07",
         "iso:id":"DM-07",
         "qs_pg:id":890046,
         "unlc:id":"DM-07",
         "wd:id":"Q1431099",
         "wk:page":"Saint Luke Parish, Dominica"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DM",
-    "wof:geomhash":"9cd16b4ff2be0cfefe89a0822b778a10",
+    "wof:geomhash":"d8726c1204ce1ee0474ef48f4e21e3ec",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -306,7 +308,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690874876,
+    "wof:lastmodified":1695884852,
     "wof:name":"Saint Luke",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/705/19/85670519.geojson
+++ b/data/856/705/19/85670519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00089,
-    "geom:area_square_m":10617109.530699,
+    "geom:area_square_m":10617175.134604,
     "geom:bbox":"-61.376129,15.201809,-61.346384,15.243799",
     "geom:latitude":15.220636,
     "geom:longitude":-61.362001,
@@ -278,14 +278,16 @@
         "gn:id":3575621,
         "gp:id":2345167,
         "hasc:id":"DM.MA",
+        "iso:code":"DM-08",
         "iso:id":"DM-08",
         "qs_pg:id":423725,
         "unlc:id":"DM-08",
         "wd:id":"Q1431115",
         "wk:page":"Saint Mark Parish, Dominica"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DM",
-    "wof:geomhash":"7ce43b1a86f37e52308aed23be405ff3",
+    "wof:geomhash":"457de280d94c08c4216b9dfc506f7111",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -300,7 +302,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690874875,
+    "wof:lastmodified":1695885134,
     "wof:name":"Saint Mark",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/705/21/85670521.geojson
+++ b/data/856/705/21/85670521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006233,
-    "geom:area_square_m":74348969.340091,
+    "geom:area_square_m":74348802.809531,
     "geom:bbox":"-61.356611,15.211697,-61.253733,15.332656",
     "geom:latitude":15.276928,
     "geom:longitude":-61.301526,
@@ -278,14 +278,16 @@
         "gn:id":3575620,
         "gp:id":2345168,
         "hasc:id":"DM.PK",
+        "iso:code":"DM-09",
         "iso:id":"DM-09",
         "qs_pg:id":890047,
         "unlc:id":"DM-09",
         "wd:id":"Q1431108",
         "wk:page":"Saint Patrick Parish, Dominica"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DM",
-    "wof:geomhash":"87eade3a16b0c69508fa333ff7230fd0",
+    "wof:geomhash":"3dd2867470f838c02d8e926fb1f61b1e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -300,7 +302,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690874875,
+    "wof:lastmodified":1695884852,
     "wof:name":"Saint Patrick",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/705/27/85670527.geojson
+++ b/data/856/705/27/85670527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005195,
-    "geom:area_square_m":61947696.320141,
+    "geom:area_square_m":61947119.424465,
     "geom:bbox":"-61.416007,15.312812,-61.32744,15.404951",
     "geom:latitude":15.362004,
     "geom:longitude":-61.368189,
@@ -275,14 +275,16 @@
         "gn:id":3575619,
         "gp:id":2345169,
         "hasc:id":"DM.PL",
+        "iso:code":"DM-10",
         "iso:id":"DM-10",
         "qs_pg:id":890048,
         "unlc:id":"DM-10",
         "wd:id":"Q339063",
         "wk:page":"Saint Paul Parish, Dominica"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DM",
-    "wof:geomhash":"7737237672c0ced82293b3e1362d4d9e",
+    "wof:geomhash":"a42bbbf847179a7ee049f33da514c9dc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -297,7 +299,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690874874,
+    "wof:lastmodified":1695884852,
     "wof:name":"Saint Paul",
     "wof:parent_id":85632503,
     "wof:placetype":"region",

--- a/data/856/705/31/85670531.geojson
+++ b/data/856/705/31/85670531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002631,
-    "geom:area_square_m":31348919.204531,
+    "geom:area_square_m":31348846.071114,
     "geom:bbox":"-61.484002,15.46633,-61.405678,15.534168",
     "geom:latitude":15.501937,
     "geom:longitude":-61.450131,
@@ -284,14 +284,16 @@
         "gn:id":3575618,
         "gp:id":2345170,
         "hasc:id":"DM.PR",
+        "iso:code":"DM-11",
         "iso:id":"DM-11",
         "qs_pg:id":984078,
         "unlc:id":"DM-11",
         "wd:id":"Q1476294",
         "wk:page":"Saint Peter Parish, Dominica"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"DM",
-    "wof:geomhash":"0aba1b961803b821de8512f871a8344a",
+    "wof:geomhash":"4ffb0ac118697262252da9dee31b247f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -306,7 +308,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690874875,
+    "wof:lastmodified":1695884852,
     "wof:name":"Saint Peter",
     "wof:parent_id":85632503,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.